### PR TITLE
Move DPD settings to database #438

### DIFF
--- a/app/Http/Controllers/Api/Settings/Module/DpdIreland/DpdIrelandController.php
+++ b/app/Http/Controllers/Api/Settings/Module/DpdIreland/DpdIrelandController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api\Settings\Module\DpdIreland;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreDpdIrelandRequest;
+use App\Modules\DpdIreland\src\Client;
+use App\Modules\DpdIreland\src\Models\DpdIreland;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DpdIrelandController extends Controller
+{
+    public function index(Request $request): JsonResource
+    {
+        $config = DpdIreland::first();
+
+        if (!$config) {
+            $this->respondNotFound('No Dpd Ireland Configuration Found');
+        } else {
+            return JsonResource::make($config);
+        }
+    }
+
+    public function store(StoreDpdIrelandRequest $request): JsonResource
+    {
+        $config = DpdIreland::first();
+
+        if (!$config) {
+            $config = DpdIreland::query()->create($request->validated());
+        } else {
+            $config->update($request->validated());
+        }
+
+        Client::clearCache();
+
+        return JsonResource::make($config);
+    }
+}

--- a/app/Http/Requests/StoreDpdIrelandRequest.php
+++ b/app/Http/Requests/StoreDpdIrelandRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDpdIrelandRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'live' => 'required|boolean',
+            'token' => 'required',
+            'user' => 'required',
+            'password' => 'required',
+            'contact' => 'required',
+            'contact_telephone' => 'required',
+            'contact_email' => 'sometimes',
+            'business_name' => 'sometimes',
+            'address_line_1' => 'sometimes',
+            'address_line_2' => 'sometimes',
+            'address_line_3' => 'required',
+            'address_line_4' => 'required',
+            'country_code' => 'required|in:IE,IRL,UK,GB',
+        ];
+    }
+}

--- a/app/Modules/DpdIreland/src/Client.php
+++ b/app/Modules/DpdIreland/src/Client.php
@@ -1,12 +1,11 @@
 <?php
 
-
 namespace App\Modules\DpdIreland\src;
 
+use App\Modules\DpdIreland\src\Models\DpdIreland;
 use Carbon\Carbon;
 use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Support\Facades\Cache;
-use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -45,7 +44,9 @@ class Client
      */
     private static function getBaseUrl(): string
     {
-        return config('dpd.live') ? self::API_URL_LIVE : self::API_URL_TEST;
+        $config = DpdIreland::firstOrFail();
+
+        return $config->live ? self::API_URL_LIVE : self::API_URL_TEST;
     }
 
     /**
@@ -56,11 +57,11 @@ class Client
     {
         $options = [
             'headers' => [
-                'Authorization' => 'Bearer '. self::getAuthorizationToken(),
+                'Authorization' => 'Bearer ' . self::getAuthorizationToken(),
                 'Content-Type' => 'application/xml; charset=UTF8',
                 'Accept' => 'application/xml',
             ],
-            'body' => $xml
+            'body' => $xml,
         ];
 
         return self::getGuzzleClient()->post(self::COMMON_API_PREADVICE, $options);
@@ -111,21 +112,23 @@ class Client
     {
         self::clearCache();
 
+        $config = DpdIreland::firstOrFail();
+
         $body = [
-            'User' => config('dpd.user'),
-            'Password' => config('dpd.password'),
+            'User' => $config->user,
+            'Password' => $config->password,
             'Type' => 'CUST',
         ];
 
         $headers = [
-            'Authorization' => 'Bearer ' . config('dpd.token'),
+            'Authorization' => 'Bearer ' . $config->token,
             'Content-Type' => 'application/json',
             'Accept' => 'application/json',
         ];
 
         $authorizationResponse = self::getGuzzleClient()->post(self::COMMON_API_AUTHORIZE, [
             'headers' => $headers,
-            'json' => $body
+            'json' => $body,
         ]);
 
         return [

--- a/app/Modules/DpdIreland/src/Models/DpdIreland.php
+++ b/app/Modules/DpdIreland/src/Models/DpdIreland.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Modules\DpdIreland\src\Models;
+
+use App\Traits\Encryptable;
+use Barryvdh\LaravelIdeHelper\Eloquent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * App\Models\Configuration
+ *
+ * @property int $id
+ * @property bool $live
+ * @property string $token
+ * @property string $user
+ * @property string $password
+ * @property string $contact
+ * @property string $contact_telephone
+ * @property string $contact_email
+ * @property string $business_name
+ * @property string $address_line_1
+ * @property string $address_line_2
+ * @property string $address_line_3
+ * @property string $address_line_4
+ * @property string $country_code
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @method static Builder|DpdIreland newModelQuery()
+ * @method static Builder|DpdIreland newQuery()
+ * @method static Builder|DpdIreland query()
+ * @method static Builder|DpdIreland first()
+ * @method static Builder|DpdIreland firstOrFail()
+ * @mixin Eloquent
+ */
+class DpdIreland extends Model
+{
+    use Encryptable;
+
+    protected $table = 'modules_dpd-ireland_configuration';
+
+    protected $fillable = [
+        'live',
+        'token',
+        'user',
+        'password',
+        'contact',
+        'contact_telephone',
+        'contact_email',
+        'business_name',
+        'address_line_1',
+        'address_line_2',
+        'address_line_3',
+        'address_line_4',
+        'country_code',
+    ];
+
+    protected $encryptable = [
+        'token', 'user', 'password',
+    ];
+
+    /**
+     * DpdIreland collection address as array
+     *
+     * @return array
+     */
+    public function getCollectionAddress(): array
+    {
+        return [
+            'Contact' => $this->attributes['contact'],
+            'ContactTelephone' => $this->attributes['contact_telephone'],
+            'ContactEmail' => $this->attributes['contact_email'],
+            'BusinessName' => $this->attributes['business_name'],
+            'AddressLine1' => $this->attributes['address_line_1'],
+            'AddressLine2' => $this->attributes['address_line_2'],
+            'AddressLine3' => $this->attributes['address_line_3'],
+            'AddressLine4' => $this->attributes['address_line_4'],
+            'CountryCode' => $this->attributes['country_code'],
+        ];
+    }
+}

--- a/app/Traits/Encryptable.php
+++ b/app/Traits/Encryptable.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Traits;
+
+trait Encryptable
+{
+    /**
+     * If the attribute is in the encryptable array
+     * then decrypt it.
+     *
+     * @param  $key
+     *
+     * @return $value
+     */
+    public function getAttribute($key)
+    {
+        $value = parent::getAttribute($key);
+        if (in_array($key, $this->encryptable) && $value != '') {
+            $value = decrypt($value);
+        }
+        return $value;
+    }
+
+    /**
+     * If the attribute is in the encryptable array
+     * then encrypt it.
+     *
+     * @param $key
+     * @param $value
+     */
+    public function setAttribute($key, $value)
+    {
+        if (in_array($key, $this->encryptable)) {
+            $value = encrypt($value);
+        }
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * When need to make sure that we iterate through
+     * all the keys.
+     *
+     * @return array
+     */
+    public function attributesToArray()
+    {
+        $attributes = parent::attributesToArray();
+        foreach ($this->encryptable as $key) {
+            if (isset($attributes[$key])) {
+                $attributes[$key] = decrypt($attributes[$key]);
+            }
+        }
+        return $attributes;
+    }
+}

--- a/database/migrations/2021_06_24_045840_create_dpd_ireland_configuration_table.php
+++ b/database/migrations/2021_06_24_045840_create_dpd_ireland_configuration_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDpdIrelandConfigurationTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('modules_dpd-ireland_configuration', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('live')->default(false);
+            $table->string('token');
+            $table->string('user');
+            $table->string('password');
+            $table->string('contact');
+            $table->string('contact_telephone');
+            $table->string('contact_email')->nullable();
+            $table->string('business_name')->nullable();
+            $table->string('address_line_1')->nullable();
+            $table->string('address_line_2')->nullable();
+            $table->string('address_line_3');
+            $table->string('address_line_4');
+            $table->string('country_code', 10);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('modules_dpd-ireland_configuration');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -26,7 +26,7 @@ class DatabaseSeeder extends Seeder
 //            Api2CartOrderImportSeeder::class,
 //            RmsapiConnectionSeeder::class,
 //            RmsapiProductImportSeeder::class,
-//
+//            DpdSeeder::class,
 //            PicksSeeder::class
         ]);
 

--- a/database/seeds/DpdSeeder.php
+++ b/database/seeds/DpdSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Modules\DpdIreland\src\Models\DpdIreland;
+use Illuminate\Database\Seeder;
+
+class DpdSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DpdIreland::query()->create([
+            'live' => false,
+            'user' => 'someuser',
+            'password' => 'somepassword',
+            'token' => 'sometoken',
+            'contact' => 'DPD Contact',
+            'contact_telephone' => '0860000000',
+            'contact_email' => 'testemail@dpd.ie',
+            'business_name' => 'DPD API Test Limited',
+            'address_line_1' => 'Athlone Business Park',
+            'address_line_2' => 'Dublin Road',
+            'address_line_3' => 'Athlone',
+            'address_line_4' => 'Co. Westmeath',
+            'country_code' => 'IE',
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,6 +54,12 @@ Route::middleware('auth:api')->group(function () {
                 Route::apiResource('connections', "Api2cartConnectionController")->only(['index', 'store', 'destroy']);
                 Route::apiResource('products', "ProductsController")->only(['index']);
             });
+
+            // dpdireland
+            Route::group(['prefix' => 'dpd-ireland', 'namespace' => 'DpdIreland', 'as' => 'dpd-ireland.'], function () {
+                Route::apiResource('', 'DpdIrelandController')->only(['index', 'store']);
+            });
+
             // printnode
             Route::group(['prefix' => 'printnode', 'namespace' => 'Printnode', 'as' => 'printnode.'], function () {
                 Route::apiResource('printers', 'PrinterController')->only(['index']);

--- a/tests/External/DpdIreland/DpdIntegrationJobTest.php
+++ b/tests/External/DpdIreland/DpdIntegrationJobTest.php
@@ -13,7 +13,7 @@ use Tests\TestCase;
 
 class DpdIntegrationJobTest extends TestCase
 {
-    use RefreshDatabase;
+    use RefreshDatabase, SeedConfiguration;
 
     /**
      * @test
@@ -53,7 +53,7 @@ class DpdIntegrationJobTest extends TestCase
         ]);
 
         $order = factory(Order::class)->create([
-            'shipping_address_id' => $address->getKey()
+            'shipping_address_id' => $address->getKey(),
         ]);
 
         try {

--- a/tests/External/DpdIreland/DpdTest.php
+++ b/tests/External/DpdIreland/DpdTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 
 class DpdTest extends TestCase
 {
-    use RefreshDatabase;
+    use RefreshDatabase, SeedConfiguration;
 
     /**
      * @test
@@ -48,7 +48,7 @@ class DpdTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'CountryCode' =>  'IE',
+                'CountryCode' => 'IE',
             ],
             'CollectionAddress' => [
                 'Contact' => 'John Smith',
@@ -59,7 +59,7 @@ class DpdTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'CountryCode' =>  'IE',
+                'CountryCode' => 'IE',
             ],
         ]);
 
@@ -86,32 +86,32 @@ class DpdTest extends TestCase
     public function successfully_generate_preadvice()
     {
         $consignment = new Consignment([
-                'RecordID' => 1,
-                'TotalParcels'=> 1,
-                'ServiceOption' => 5,
-                'ServiceType' => 1,
-                'DeliveryAddress' => [
-                    'Contact' => 'John Smith',
-                    'ContactTelephone' => '12345678901',
-                    'ContactEmail' => 'john.smith@ie.ie',
-                    'BusinessName' => 'JS Business',
-                    'AddressLine1' => 'DPD Ireland, Westmeath',
-                    'AddressLine2' => 'Unit 2B Midland Gateway Bus',
-                    'AddressLine3' => 'Kilbeggan',
-                    'AddressLine4' => 'Westmeath',
-                    'CountryCode' =>  'IE',
-                ],
-                'CollectionAddress' => [
-                    'Contact' => 'John Smith',
-                    'ContactTelephone' => '12345678901',
-                    'ContactEmail' => 'john.smith@ie.ie',
-                    'BusinessName' => 'JS Business',
-                    'AddressLine1' => 'DPD Ireland, Westmeath',
-                    'AddressLine2' => 'Unit 2B Midland Gateway Bus',
-                    'AddressLine3' => 'Kilbeggan',
-                    'AddressLine4' => 'Westmeath',
-                    'CountryCode' =>  'IE',
-                ],
+            'RecordID' => 1,
+            'TotalParcels' => 1,
+            'ServiceOption' => 5,
+            'ServiceType' => 1,
+            'DeliveryAddress' => [
+                'Contact' => 'John Smith',
+                'ContactTelephone' => '12345678901',
+                'ContactEmail' => 'john.smith@ie.ie',
+                'BusinessName' => 'JS Business',
+                'AddressLine1' => 'DPD Ireland, Westmeath',
+                'AddressLine2' => 'Unit 2B Midland Gateway Bus',
+                'AddressLine3' => 'Kilbeggan',
+                'AddressLine4' => 'Westmeath',
+                'CountryCode' => 'IE',
+            ],
+            'CollectionAddress' => [
+                'Contact' => 'John Smith',
+                'ContactTelephone' => '12345678901',
+                'ContactEmail' => 'john.smith@ie.ie',
+                'BusinessName' => 'JS Business',
+                'AddressLine1' => 'DPD Ireland, Westmeath',
+                'AddressLine2' => 'Unit 2B Midland Gateway Bus',
+                'AddressLine3' => 'Kilbeggan',
+                'AddressLine4' => 'Westmeath',
+                'CountryCode' => 'IE',
+            ],
         ]);
 
         $preAdvice = Dpd::getPreAdvice($consignment);

--- a/tests/External/DpdIreland/NormalOvernightTest.php
+++ b/tests/External/DpdIreland/NormalOvernightTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Tests\External\DpdIreland;
-
 
 use App\Modules\DpdIreland\Dpd;
 use App\Modules\DpdIreland\src\Consignment;
@@ -10,6 +8,8 @@ use Tests\TestCase;
 
 class NormalOvernightTest extends TestCase
 {
+    use SeedConfiguration;
+
     /**
      * @test
      */
@@ -25,7 +25,7 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'CountryCode'  =>  'IE',
+                'CountryCode' => 'IE',
             ],
             'CollectionAddress' => [
                 'Contact' => 'John Smith',
@@ -36,8 +36,8 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'PostCode'     => 'XYZ1234',
-                'CountryCode' =>  'IE',
+                'PostCode' => 'XYZ1234',
+                'CountryCode' => 'IE',
             ],
         ]);
 
@@ -52,7 +52,7 @@ class NormalOvernightTest extends TestCase
     public function normal_overnight_consignment_between_2_and_10_parcels()
     {
         $consignment = new Consignment([
-            'TotalParcels' => rand(2,10),
+            'TotalParcels' => rand(2, 10),
             'DeliveryAddress' => [
                 'Contact' => 'John Smith',
                 'ContactTelephone' => '12345678901',
@@ -62,7 +62,7 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'CountryCode' =>  'IE',
+                'CountryCode' => 'IE',
             ],
             'CollectionAddress' => [
                 'Contact' => 'John Smith',
@@ -73,8 +73,8 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'PostCode'     => 'XYZ1234',
-                'CountryCode' =>  'IE',
+                'PostCode' => 'XYZ1234',
+                'CountryCode' => 'IE',
             ],
         ]);
 
@@ -89,7 +89,7 @@ class NormalOvernightTest extends TestCase
     public function normal_overnight_consignment_more_than_10_parcels()
     {
         $consignment = new Consignment([
-            'TotalParcels' => rand(11,20),
+            'TotalParcels' => rand(11, 20),
             'DeliveryAddress' => [
                 'Contact' => 'John Smith',
                 'ContactTelephone' => '12345678901',
@@ -99,7 +99,7 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'CountryCode' =>  'IE',
+                'CountryCode' => 'IE',
             ],
             'CollectionAddress' => [
                 'Contact' => 'John Smith',
@@ -110,8 +110,8 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'PostCode'     => 'XYZ1234',
-                'CountryCode' =>  'IE',
+                'PostCode' => 'XYZ1234',
+                'CountryCode' => 'IE',
             ],
         ]);
 
@@ -126,7 +126,7 @@ class NormalOvernightTest extends TestCase
     public function if_succeeds_with_wrong_postcode()
     {
         $consignment = new Consignment([
-            'TotalParcels' => rand(11,20),
+            'TotalParcels' => rand(11, 20),
             'DeliveryAddress' => [
                 'Contact' => 'John Smith',
                 'ContactTelephone' => '12345678901',
@@ -136,8 +136,8 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'PostCode'     => 'XYZ12345678901234',
-                'CountryCode' =>  'IE',
+                'PostCode' => 'XYZ12345678901234',
+                'CountryCode' => 'IE',
             ],
             'CollectionAddress' => [
                 'Contact' => 'John Smith',
@@ -148,8 +148,8 @@ class NormalOvernightTest extends TestCase
                 'AddressLine2' => 'Unit 2B Midland Gateway Bus',
                 'AddressLine3' => 'Kilbeggan',
                 'AddressLine4' => 'Westmeath',
-                'PostCode'     => 'XYZ1234',
-                'CountryCode' =>  'IE',
+                'PostCode' => 'XYZ1234',
+                'CountryCode' => 'IE',
             ],
         ]);
 

--- a/tests/External/DpdIreland/PrintDpdLabelControllerTest.php
+++ b/tests/External/DpdIreland/PrintDpdLabelControllerTest.php
@@ -13,7 +13,7 @@ use Tests\TestCase;
  */
 class PrintDpdLabelControllerTest extends TestCase
 {
-    use RefreshDatabase;
+    use RefreshDatabase, SeedConfiguration;
 
     /**
      * @test
@@ -21,7 +21,7 @@ class PrintDpdLabelControllerTest extends TestCase
     public function storeReturnsOkResponse()
     {
         $user = factory(User::class)->create([
-            'address_label_template' => 'dpd_label'
+            'address_label_template' => 'dpd_label',
         ]);
 
         $address = factory(OrderAddress::class)->create([
@@ -32,14 +32,14 @@ class PrintDpdLabelControllerTest extends TestCase
             'city' => 'Dublin',
             'state_name' => 'Co. Dublin',
             'postcode' => 'ABC1234',
-            'country_code' => 'IRL'
+            'country_code' => 'IRL',
         ]);
 
         $order = factory(Order::class)->create([
-            'shipping_address_id' => $address->getKey()
+            'shipping_address_id' => $address->getKey(),
         ]);
 
-        $response = $this->actingAs($user, 'api')->putJson('api/print/order/'. $order->order_number .'/dpd_label', [
+        $response = $this->actingAs($user, 'api')->putJson('api/print/order/' . $order->order_number . '/dpd_label', [
             // TODO: send request data
         ]);
 

--- a/tests/External/DpdIreland/SeedConfiguration.php
+++ b/tests/External/DpdIreland/SeedConfiguration.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\External\DpdIreland;
+
+use App\Modules\DpdIreland\src\Models\DpdIreland;
+
+trait SeedConfiguration
+{
+    /**
+     * Delete previous DpdIreland configuration and create a new one
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        DpdIreland::query()->delete();
+        DpdIreland::query()->create([
+            'live' => false,
+            'user' => 'someuser',
+            'password' => 'somepassword',
+            'token' => 'sometoken',
+            'contact' => 'DPD Contact',
+            'contact_telephone' => '0860000000',
+            'contact_email' => 'testemail@dpd.ie',
+            'business_name' => 'DPD API Test Limited',
+            'address_line_1' => 'Athlone Business Park',
+            'address_line_2' => 'Dublin Road',
+            'address_line_3' => 'Athlone',
+            'address_line_4' => 'Co. Westmeath',
+            'country_code' => 'IE',
+        ]);
+    }
+}

--- a/tests/Feature/Http/Controllers/Api/Settings/Module/DpdIreland/DpdIrelandController/IndexTest.php
+++ b/tests/Feature/Http/Controllers/Api/Settings/Module/DpdIreland/DpdIrelandController/IndexTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Api\Settings\Module\DpdIreland\DpdIrelandController;
+
+use App\Modules\DpdIreland\src\Models\DpdIreland;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function test_index_call_without_config()
+    {
+        $user = factory(User::class)->create();
+        $response = $this->actingAs($user, 'api')->get(route('api.settings.module.dpd-ireland.index'));
+        $response->assertNotFound();
+    }
+
+    /** @test */
+    public function test_index_call_with_config()
+    {
+        DpdIreland::query()->create([
+            'live' => false,
+            'user' => 'someuser',
+            'password' => 'somepassword',
+            'token' => 'sometoken',
+            'contact' => 'DPD Contact',
+            'contact_telephone' => '0860000000',
+            'contact_email' => 'testemail@dpd.ie',
+            'business_name' => 'DPD API Test Limited',
+            'address_line_1' => 'Athlone Business Park',
+            'address_line_2' => 'Dublin Road',
+            'address_line_3' => 'Athlone',
+            'address_line_4' => 'Co. Westmeath',
+            'country_code' => 'IE',
+        ]);
+
+        $user = factory(User::class)->create();
+        $response = $this->actingAs($user, 'api')->get(route('api.settings.module.dpd-ireland.index'));
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/Http/Controllers/Api/Settings/Module/DpdIreland/DpdIrelandController/StoreTest.php
+++ b/tests/Feature/Http/Controllers/Api/Settings/Module/DpdIreland/DpdIrelandController/StoreTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Api\Settings\Module\DpdIreland\DpdIrelandController;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function test_config_update()
+    {
+        $user = factory(User::class)->create();
+        $response = $this->actingAs($user, 'api')->post(route('api.settings.module.dpd-ireland.store'), [
+            'live' => false,
+            'user' => 'someuser',
+            'password' => 'somepassword',
+            'token' => 'sometoken',
+            'contact' => 'DPD Contact',
+            'contact_telephone' => '0860000000',
+            'contact_email' => 'testemail@dpd.ie',
+            'business_name' => 'DPD API Test Limited',
+            'address_line_1' => 'Athlone Business Park',
+            'address_line_2' => 'Dublin Road',
+            'address_line_3' => 'Athlone',
+            'address_line_4' => 'Co. Westmeath',
+            'country_code' => 'IE',
+        ]);
+
+        $response->assertSuccessful();
+    }
+}


### PR DESCRIPTION
Move DPD Settings into Database

Added 2 routes
Added modules_dpd-ireland_configuration table
Added DpdIreland model class
Modify existing Dpd module to use Dpd configuration from the database. If the configuration is not found while using dpd module, it will throw an exception
Test case for dpd controller